### PR TITLE
feature/log-target-support 

### DIFF
--- a/annotations/src/main/java/nl/openweb/hippo/groovy/annotations/Updater.java
+++ b/annotations/src/main/java/nl/openweb/hippo/groovy/annotations/Updater.java
@@ -44,4 +44,6 @@ public @interface Updater {
     long throttle() default 1000L;
 
     String mixin() default "";
+
+    String logTarget() default "";
 }

--- a/annotations/src/main/java/nl/openweb/hippo/groovy/annotations/Updater.java
+++ b/annotations/src/main/java/nl/openweb/hippo/groovy/annotations/Updater.java
@@ -27,6 +27,22 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Updater {
+    enum LogTarget {
+        DEFAULT(""),
+        LOG_FILES("LOG FILES"),
+        REPOSITORY("REPOSITORY");
+
+        private final String value;
+
+        LogTarget(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
     String name();
 
     String description() default "";
@@ -45,5 +61,5 @@ public @interface Updater {
 
     String mixin() default "";
 
-    String logTarget() default "";
+    LogTarget logTarget() default LogTarget.DEFAULT;
 }

--- a/bootstrapgenerator/src/main/java/nl/openweb/hippo/groovy/PropertyCollector.java
+++ b/bootstrapgenerator/src/main/java/nl/openweb/hippo/groovy/PropertyCollector.java
@@ -80,8 +80,8 @@ public class PropertyCollector {
         if (StringUtils.isNotBlank(updater.mixin())) {
             addPropertyIfNotEmpty(properties, JCR_MIXIN_TYPES, createMultiValueProperty(updater.mixin()));
         }
-        if (StringUtils.isNotBlank(updater.logTarget())) {
-            addPropertyIfNotEmpty(properties, HIPPOSYS_LOGTARGET, updater.logTarget());
+        if (StringUtils.isNotBlank(updater.logTarget().toString())) {
+            addPropertyIfNotEmpty(properties, HIPPOSYS_LOGTARGET, updater.logTarget().toString());
         }
         addPropertyIfNotEmpty(properties, HIPPOSYS_PARAMETERS, getValueOrFileContent(script, sourceDir, updater.parameters()));
         if (StringUtils.isBlank(updater.xpath())) {

--- a/bootstrapgenerator/src/main/java/nl/openweb/hippo/groovy/PropertyCollector.java
+++ b/bootstrapgenerator/src/main/java/nl/openweb/hippo/groovy/PropertyCollector.java
@@ -18,6 +18,7 @@ package nl.openweb.hippo.groovy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -31,6 +32,7 @@ import static nl.openweb.hippo.groovy.model.Constants.NodeType.HIPPOSYS_UPDATERI
 import static nl.openweb.hippo.groovy.model.Constants.PropertyName.HIPPOSYS_BATCHSIZE;
 import static nl.openweb.hippo.groovy.model.Constants.PropertyName.HIPPOSYS_DESCRIPTION;
 import static nl.openweb.hippo.groovy.model.Constants.PropertyName.HIPPOSYS_DRYRUN;
+import static nl.openweb.hippo.groovy.model.Constants.PropertyName.HIPPOSYS_LOGTARGET;
 import static nl.openweb.hippo.groovy.model.Constants.PropertyName.HIPPOSYS_PARAMETERS;
 import static nl.openweb.hippo.groovy.model.Constants.PropertyName.HIPPOSYS_PATH;
 import static nl.openweb.hippo.groovy.model.Constants.PropertyName.HIPPOSYS_QUERY;
@@ -56,7 +58,7 @@ public class PropertyCollector {
         if (file.exists()) {
             try {
                 return ScriptClassFactory.readFileEnsuringLinuxLineEnding(file);
-            } catch (IOException e) {
+            } catch (IOException | InvalidPathException e) {
                 //do nothing, it's fine
             }
         }
@@ -77,6 +79,9 @@ public class PropertyCollector {
         properties.put(HIPPOSYS_DRYRUN, updater.dryRun());
         if (StringUtils.isNotBlank(updater.mixin())) {
             addPropertyIfNotEmpty(properties, JCR_MIXIN_TYPES, createMultiValueProperty(updater.mixin()));
+        }
+        if (StringUtils.isNotBlank(updater.logTarget())) {
+            addPropertyIfNotEmpty(properties, HIPPOSYS_LOGTARGET, updater.logTarget());
         }
         addPropertyIfNotEmpty(properties, HIPPOSYS_PARAMETERS, getValueOrFileContent(script, sourceDir, updater.parameters()));
         if (StringUtils.isBlank(updater.xpath())) {

--- a/bootstrapgenerator/src/main/java/nl/openweb/hippo/groovy/model/Constants.java
+++ b/bootstrapgenerator/src/main/java/nl/openweb/hippo/groovy/model/Constants.java
@@ -42,6 +42,7 @@ public final class Constants {
         public static final String JCR_MIXIN_TYPES = "jcr:mixinTypes";
         public static final String HIPPOSYS_BATCHSIZE = "hipposys:batchsize";
         public static final String HIPPOSYS_DRYRUN = "hipposys:dryrun";
+        public static final String HIPPOSYS_LOGTARGET = "hipposys:logtarget";
         public static final String HIPPOSYS_PARAMETERS = "hipposys:parameters";
         public static final String HIPPOSYS_QUERY = "hipposys:query";
         public static final String HIPPOSYS_SCRIPT = "hipposys:script";

--- a/bootstrapgenerator/src/test/java/YamlGeneratorTest.java
+++ b/bootstrapgenerator/src/test/java/YamlGeneratorTest.java
@@ -33,7 +33,7 @@ import static nl.openweb.hippo.groovy.YamlGenerator.getYamlString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public class YamlGeneratorTest {
+class YamlGeneratorTest {
 
     final File sourceDir = new File(getClass().getResource("/").toURI());
 
@@ -46,12 +46,12 @@ public class YamlGeneratorTest {
     }
 
     @Test
-    public void testScrubbingAnnotations() throws IOException, URISyntaxException {
+    void testScrubbingAnnotations() throws IOException, URISyntaxException {
         checkGeneration("sub/annotatestrip");
     }
 
     @Test
-    public void testUpdatescriptCreating() throws URISyntaxException, IOException {
+    void testUpdatescriptCreating() throws URISyntaxException, IOException {
         checkGeneration("updater");
         checkGeneration("updater2");
         checkGeneration("updater3");
@@ -61,6 +61,7 @@ public class YamlGeneratorTest {
         checkGeneration("updaterdata/updater5");
         checkGeneration("updaterdata/updater6");
         checkGeneration("updaterdata/updater7");
+        checkGeneration("updaterdata/updater-logtarget");
     }
 
     private void checkGeneration(String name) throws URISyntaxException, IOException {
@@ -79,7 +80,7 @@ public class YamlGeneratorTest {
     }
 
     @Test
-    public void checkDefaultingContentRootYamlFile() throws URISyntaxException, IOException {
+    void checkDefaultingContentRootYamlFile() throws URISyntaxException, IOException {
         Generator.setDefaultContentRoot(Bootstrap.ContentRoot.REGISTRY);
         URL testfileUrl = getClass().getResource("updater.groovy");
         URL testfileResultUrlYaml = getClass().getResource("updater.yaml");

--- a/bootstrapgenerator/src/test/resources/updaterdata/updater-logtarget.groovy
+++ b/bootstrapgenerator/src/test/resources/updaterdata/updater-logtarget.groovy
@@ -1,0 +1,18 @@
+import nl.openweb.hippo.groovy.annotations.Bootstrap
+import nl.openweb.hippo.groovy.annotations.Updater
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+
+@Bootstrap(contentroot = Bootstrap.ContentRoot.REGISTRY, reload = true, version = "1.6")
+@Updater(name = "Test Updater Log Target", path = "/content", description = "Test thing", batchSize = 1L, throttle = 200L, dryRun = true, parameters = "{prop: val}", logTarget = "REPOSITORY")
+class TestUpdaterLogTarget extends BaseNodeUpdateVisitor {
+    boolean doUpdate(Node node) {
+        log.info "manipulate node < > & an %^&* /> {}", node.path
+        return true
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException('Updater does not implement undoUpdate method')
+    }
+}

--- a/bootstrapgenerator/src/test/resources/updaterdata/updater-logtarget.groovy
+++ b/bootstrapgenerator/src/test/resources/updaterdata/updater-logtarget.groovy
@@ -5,7 +5,7 @@ import org.onehippo.repository.update.BaseNodeUpdateVisitor
 import javax.jcr.Node
 
 @Bootstrap(contentroot = Bootstrap.ContentRoot.REGISTRY, reload = true, version = "1.6")
-@Updater(name = "Test Updater Log Target", path = "/content", description = "Test thing", batchSize = 1L, throttle = 200L, dryRun = true, parameters = "{prop: val}", logTarget = "REPOSITORY")
+@Updater(name = "Test Updater Log Target", path = "/content", description = "Test thing", batchSize = 1L, throttle = 200L, dryRun = true, parameters = "{prop: val}", logTarget = Updater.LogTarget.REPOSITORY)
 class TestUpdaterLogTarget extends BaseNodeUpdateVisitor {
     boolean doUpdate(Node node) {
         log.info "manipulate node < > & an %^&* /> {}", node.path

--- a/bootstrapgenerator/src/test/resources/updaterdata/updater-logtarget.yaml
+++ b/bootstrapgenerator/src/test/resources/updaterdata/updater-logtarget.yaml
@@ -1,0 +1,26 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/Test Updater Log Target:
+      jcr:primaryType: hipposys:updaterinfo
+      hipposys:batchsize: 1
+      hipposys:description: Test thing
+      hipposys:dryrun: true
+      hipposys:logtarget: REPOSITORY
+      hipposys:parameters: '{prop: val}'
+      hipposys:path: /content
+      hipposys:script: |-
+        import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+        import javax.jcr.Node
+
+        class TestUpdaterLogTarget extends BaseNodeUpdateVisitor {
+            boolean doUpdate(Node node) {
+                log.info "manipulate node < > & an %^&* /> {}", node.path
+                return true
+            }
+
+            boolean undoUpdate(Node node) {
+                throw new UnsupportedOperationException('Updater does not implement undoUpdate method')
+            }
+        }
+      hipposys:throttle: 200


### PR DESCRIPTION
feature added by bloomreach to help configure if logs of groovy-scripts should be logged to log files or be available in the ui. They introduced the hipposys:logtarget for this. official documentation has dissappeared this morning ;)